### PR TITLE
DO NOT MERGE - Introduce 'entrypoint.sh' for some Containers

### DIFF
--- a/comps/llms/summarization/tgi/Dockerfile
+++ b/comps/llms/summarization/tgi/Dockerfile
@@ -24,4 +24,4 @@ ENV PYTHONPATH=$PYTHONPATH:/home/user
 
 WORKDIR /home/user/comps/llms/summarization/tgi
 
-ENTRYPOINT ["python", "llm.py"]
+ENTRYPOINT ["bash", "entrypoint.sh"]

--- a/comps/llms/summarization/tgi/entrypoint.sh
+++ b/comps/llms/summarization/tgi/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+pip --no-cache-dir install -r requirements-runtime.txt
+
+python llm.py

--- a/comps/llms/summarization/tgi/requirements-runtime.txt
+++ b/comps/llms/summarization/tgi/requirements-runtime.txt
@@ -1,0 +1,1 @@
+langserve

--- a/comps/llms/summarization/tgi/requirements.txt
+++ b/comps/llms/summarization/tgi/requirements.txt
@@ -2,7 +2,6 @@ docarray[full]
 fastapi
 huggingface_hub
 langchain==0.1.16
-langserve
 langsmith
 opentelemetry-api
 opentelemetry-exporter-otlp

--- a/comps/llms/text-generation/ollama/Dockerfile
+++ b/comps/llms/text-generation/ollama/Dockerfile
@@ -25,4 +25,4 @@ ENV PYTHONPATH=$PYTHONPATH:/home/user
 
 WORKDIR /home/user/comps/llms/text-generation/ollama
 
-ENTRYPOINT ["python", "llm.py"]
+ENTRYPOINT ["bash", "entrypoint.sh"]

--- a/comps/llms/text-generation/ollama/entrypoint.sh
+++ b/comps/llms/text-generation/ollama/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+pip --no-cache-dir install -r requirements-runtime.txt
+
+python llm.py

--- a/comps/llms/text-generation/ollama/requirements-runtime.txt
+++ b/comps/llms/text-generation/ollama/requirements-runtime.txt
@@ -1,0 +1,1 @@
+langserve

--- a/comps/llms/text-generation/ollama/requirements.txt
+++ b/comps/llms/text-generation/ollama/requirements.txt
@@ -2,7 +2,6 @@ docarray[full]
 fastapi
 huggingface_hub
 langchain==0.1.16
-langserve
 langsmith
 opentelemetry-api
 opentelemetry-exporter-otlp

--- a/comps/llms/text-generation/ray_serve/docker/Dockerfile.microservice
+++ b/comps/llms/text-generation/ray_serve/docker/Dockerfile.microservice
@@ -34,4 +34,4 @@ ENV PYTHONPATH=$PYTHONPATH:/home/user
 
 WORKDIR /home/user/comps/llms/text-generation/ray_serve
 
-ENTRYPOINT ["python", "llm.py"]
+ENTRYPOINT ["bash", "entrypoint.sh"]

--- a/comps/llms/text-generation/ray_serve/entrypoint.sh
+++ b/comps/llms/text-generation/ray_serve/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+pip --no-cache-dir install -r requirements-runtime.txt
+
+python llm.py

--- a/comps/llms/text-generation/ray_serve/requirements-runtime.txt
+++ b/comps/llms/text-generation/ray_serve/requirements-runtime.txt
@@ -1,0 +1,1 @@
+langserve

--- a/comps/llms/text-generation/ray_serve/requirements.txt
+++ b/comps/llms/text-generation/ray_serve/requirements.txt
@@ -3,7 +3,6 @@ fastapi
 huggingface_hub
 langchain==0.1.16
 langchain_openai
-langserve
 langsmith
 openai
 opentelemetry-api

--- a/comps/llms/text-generation/tgi/Dockerfile
+++ b/comps/llms/text-generation/tgi/Dockerfile
@@ -24,4 +24,4 @@ ENV PYTHONPATH=$PYTHONPATH:/home/user
 
 WORKDIR /home/user/comps/llms/text-generation/tgi
 
-ENTRYPOINT ["python", "llm.py"]
+ENTRYPOINT ["bash", "entrypoint.sh"]

--- a/comps/llms/text-generation/tgi/entrypoint.sh
+++ b/comps/llms/text-generation/tgi/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+pip --no-cache-dir install -r requirements-runtime.txt
+
+python llm.py

--- a/comps/llms/text-generation/tgi/requirements-runtime.txt
+++ b/comps/llms/text-generation/tgi/requirements-runtime.txt
@@ -1,0 +1,1 @@
+langserve

--- a/comps/llms/text-generation/tgi/requirements.txt
+++ b/comps/llms/text-generation/tgi/requirements.txt
@@ -2,7 +2,6 @@ docarray[full]
 fastapi
 huggingface_hub
 langchain==0.1.16
-langserve
 langsmith
 opentelemetry-api
 opentelemetry-exporter-otlp

--- a/comps/llms/text-generation/vllm/docker/Dockerfile.microservice
+++ b/comps/llms/text-generation/vllm/docker/Dockerfile.microservice
@@ -29,4 +29,4 @@ ENV PYTHONPATH=$PYTHONPATH:/home/user
 
 WORKDIR /home/user/comps/llms/text-generation/vllm
 
-ENTRYPOINT ["python", "llm.py"]
+ENTRYPOINT ["bash", "entrypoint.sh"]

--- a/comps/llms/text-generation/vllm/entrypoint.sh
+++ b/comps/llms/text-generation/vllm/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+pip --no-cache-dir install -r requirements-runtime.txt
+
+python llm.py

--- a/comps/llms/text-generation/vllm/requirements-runtime.txt
+++ b/comps/llms/text-generation/vllm/requirements-runtime.txt
@@ -1,0 +1,1 @@
+langserve

--- a/comps/llms/text-generation/vllm/requirements.txt
+++ b/comps/llms/text-generation/vllm/requirements.txt
@@ -2,7 +2,6 @@ docarray[full]
 fastapi
 huggingface_hub
 langchain==0.1.16
-langserve
 opentelemetry-api
 opentelemetry-exporter-otlp
 opentelemetry-sdk

--- a/comps/ragas/tgi/Dockerfile
+++ b/comps/ragas/tgi/Dockerfile
@@ -23,4 +23,4 @@ ENV PYTHONPATH=$PYTHONPATH:/home/user
 
 WORKDIR /home/user/comps/ragas/tgi/
 
-ENTRYPOINT ["python", "llm.py"]
+ENTRYPOINT ["bash", "entrypoint.sh"]

--- a/comps/ragas/tgi/entrypoint.sh
+++ b/comps/ragas/tgi/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+pip --no-cache-dir install -r requirements-runtime.txt
+
+python llm.py

--- a/comps/ragas/tgi/requirements-runtime.txt
+++ b/comps/ragas/tgi/requirements-runtime.txt
@@ -1,0 +1,1 @@
+langserve

--- a/comps/ragas/tgi/requirements.txt
+++ b/comps/ragas/tgi/requirements.txt
@@ -3,7 +3,6 @@ docarray[full]
 fastapi
 huggingface_hub
 langchain==0.1.16
-langserve
 langsmith
 opentelemetry-api
 opentelemetry-exporter-otlp


### PR DESCRIPTION
## Description

This PR introduces an `entrypoint.sh` script to be run at Container startup which is a very common practice by Container developers.

## Issues
There are times where more than a single command is required to be run at container entry point and having a script would simplify the Dockerfile design greatly.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [N/A] Bug fix (non-breaking change which fixes an issue)
- [X] New feature - Pack multiple commands into an script and run that script at Container startup rather than a single command within the body of the container
- [N/A] Breaking change (fix or feature that would break existing design and interface)

## Dependencies

None.

## Tests

- Container builds are successful
- Running the `entrypoint.sh` script is relatively fast and does not introduce unacceptable wait time for prompt to be ready
- Running containers produces output similar to the following which is the expected result:
```
[2024-07-03 23:35:26,145] [    INFO] - CORS is enabled.
[2024-07-03 23:35:26,146] [    INFO] - Setting up HTTP server
[2024-07-03 23:35:26,146] [    INFO] - Uvicorn server setup on port 9000
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:9000 (Press CTRL+C to quit)
[2024-07-03 23:35:26,162] [    INFO] - HTTP server setup successful
```